### PR TITLE
Add GitHub MCP server configuration (MIGRATED)

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -9,6 +9,10 @@
             "env": {
                 "LOADMILL_API_TOKEN": "${input:loadmill-api-token}"
             }
+        },
+        "github": {
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/"
         }
     },
     "inputs": [


### PR DESCRIPTION
## Migrated to Upstream Repository

This PR has been migrated to the upstream repository: https://github.com/loadmill/maker-checker-demo/pull/5

Closing this PR in favor of the upstream contribution.